### PR TITLE
TES-221 | Pantalla carrito de compras vacío

### DIFF
--- a/src/app/(shop)/empty/page.tsx
+++ b/src/app/(shop)/empty/page.tsx
@@ -1,10 +1,18 @@
-import { titleFont } from "@/config/fonts";
+import Link from "next/link";
+import { IoArrowBackOutline, IoCartOutline } from "react-icons/io5";
 
 
 export default function EmptyPage() {
     return (
-        <section>
-            <h2 className={`${ titleFont.className } font-bold `} > Empty page </h2>
+        <section className="flex justify-center items-center h-[800px]">
+            <IoCartOutline size={120} className="mx-5" />
+            <div className="flex flex-col items-center">
+                <h1 className="text-4xl font-semibold"> Carrito Vacío </h1>
+                <Link href='/' className="group flex justify-center items-center text-xl text-slate-600 mt-2 underline hover:text-slate-900">
+                    <IoArrowBackOutline className="mr-1 transition-all group-hover:-translate-x-3" size={25}/>
+                    <span>Regresar</span>
+                </Link>
+            </div>
         </section>
     )
 }


### PR DESCRIPTION
Creación inicial de pantalla de carrito de compras si el usuario aún no selecciono ningún artículo, si decide regresar es redireccionado a la pantalla de inicio/home de app.

![image](https://github.com/user-attachments/assets/87d1abfa-57f4-4743-8263-ebf3c451feb3)
![image](https://github.com/user-attachments/assets/a7650391-fdfc-4c73-9eab-86afa2780bf8)
![image](https://github.com/user-attachments/assets/6571c6ff-07dc-43c9-bfcf-102210451994)
